### PR TITLE
fix: Correct error in pyhf.patchset.Patch API

### DIFF
--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -102,7 +102,7 @@ def main(args):
         task_id = fxc.run(
             workspace,
             patch.metadata,
-            [patch],
+            [patch.patch],
             endpoint_id=pyhf_endpoint,
             function_id=infer_func,
         )

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -82,7 +82,7 @@ def main(args):
         pallet_path.joinpath(f"{analysis_prefix_str}patchset.json")
     ) as patchset_json:
         patchset = pyhf.PatchSet(json.load(patchset_json))
-    patch = patchset.patches[0]
+    patch = patchset.patches[0].patch
 
     workspace = None
     while not workspace:


### PR DESCRIPTION
@lukasheinrich noted that I had a bug in the [`pyhf.patchset.Patch` API](https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.patchset.Patch.html) :grimacing: 

```
* Use correct Patch API
   - c.f. https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.patchset.Patch.html
   
Co-authored-by: Lukas <lukas.heinrich@gmail.com>
```