### PR TITLE
fix: Use pyhf v0.6.x+ API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,8 @@ repos:
     - id: end-of-file-fixer
     - id: mixed-line-ending
     - id: trailing-whitespace
+
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.5b1
     hooks:
     - id: black

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -33,8 +33,6 @@ def infer_hypotest(workspace, metadata, patches):
         "metadata": metadata,
         "CLs_obs": float(
             pyhf.infer.hypotest(test_poi, data, model, test_stat="qtilde")
-            # Use v0.5.4 API until endpoint fixed
-            # pyhf.infer.hypotest(test_poi, data, model, qtilde=True)
         ),
         "Fit-Time": time.time() - tick,
     }

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -32,9 +32,9 @@ def infer_hypotest(workspace, metadata, patches):
     return {
         "metadata": metadata,
         "CLs_obs": float(
-            # pyhf.infer.hypotest(test_poi, data, model, test_stat="qtilde")
+            pyhf.infer.hypotest(test_poi, data, model, test_stat="qtilde")
             # Use v0.5.4 API until endpoint fixed
-            pyhf.infer.hypotest(test_poi, data, model, qtilde=True)
+            # pyhf.infer.hypotest(test_poi, data, model, qtilde=True)
         ),
         "Fit-Time": time.time() - tick,
     }


### PR DESCRIPTION
The original deployment of the funcX endpoint was using a release of `pyhf` that was in the `v0.5.x` release series. This is no longer used, so it is safe to use the `pyhf` `v0.6.x` API everywhere. Additionally update the Black pre-commit hook.

```
* Use pyhf v0.6.x API everywhere
   - All endpoints are no longer using v0.5.x releases
* Update Black pre-commit hook to v21.5b1
```