### PR TITLE
ci: Add pre-commit.ci for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+  autoupdate_commit_msg: "chore: [pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: "quarterly"
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Distributed Inference with `pyhf` and `funcX`
 
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/matthewfeickert/distributed-inference-with-pyhf-and-funcX/main.svg)](https://results.pre-commit.ci/latest/github/matthewfeickert/distributed-inference-with-pyhf-and-funcX/main)
+
 Example code for vCHEP 2021 paper "Distributed statistical inference with pyhf enabled through funcX"
 
 ## Setup


### PR DESCRIPTION
Use the excellent and speedy `pre-commit.ci` for linting on PRs.

```
* Add pre-commit.ci to project and add pre-commit.ci configuration options to pre-commit
   - Use semantic PR commit titles and run autoupdates as infrequently as possible
* Add pre-commit.ci badge to README
```