### PR TITLE
feat: Add JAX dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN apt-get update -y && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
 COPY core-requirements.txt .
-RUN pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    pip install -r core-requirements.txt
+RUN python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install -r core-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN apt-get update -y && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
 COPY core-requirements.txt .
-RUN pip install --upgrade pip setuptools wheel && \
+RUN pip --no-cache-dir install --upgrade pip setuptools wheel && \
     pip install -r core-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,7 @@ RUN apt-get update -y && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
 COPY core-requirements.txt .
+COPY jax-requirements.txt .
 RUN python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install -r core-requirements.txt
+    python -m pip --no-cache-dir install --requirement core-requirements.txt && \
+    python -m pip --no-cache-dir install --requirement jax-requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ default: image
 all: image
 
 image:
+	docker pull python:3.8-buster
 	docker build . \
 	--pull \
 	--file Dockerfile \


### PR DESCRIPTION
Add JAX dependencies to Dockerfile. (Note at time of PR this isn't super useful as the base image is not GPU compatible, but can still be used for autodiff).

Also use `python -m pip --no-cache-dir` option for best practices in Docker and to reduce the Docker image size. 

```
* Add JAX dependencies to Dockerfile to use autodiff
* Use pip --no-cache-dir option for best practices
* Add base image pull to Makefile
```