### PR TITLE
feat: Add backend argparse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,19 @@ This will be read in during the run.
 Pass the config JSON file for the analysis you want to run to `fit_analysis.json`
 
 ```
-(distributed-inference) $ python fit_analysis.py -c config/1Lbb.json
+(distributed-inference) $ python fit_analysis.py -c config/1Lbb.json -b numpy
+```
+
+```console
+$ python fit_analysis.py --help
+usage: fit_analysis.py [-h] [-c CONFIG_FILE] [-b BACKEND]
+
+configuration arguments provided at run time from the CLI
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CONFIG_FILE, --config-file CONFIG_FILE
+                        config file
+  -b BACKEND, --backend BACKEND
+                        pyhf backend str alias
 ```

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -11,6 +11,8 @@ from pyhf.contrib.utils import download
 def prepare_workspace(data):
     import pyhf
 
+    pyhf.set_backend("jax")
+
     return pyhf.Workspace(data)
 
 
@@ -18,6 +20,8 @@ def infer_hypotest(workspace, metadata, patches):
     import time
 
     import pyhf
+
+    pyhf.set_backend("jax")
 
     tick = time.time()
     model = workspace.model(

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -8,20 +8,20 @@ from funcx.sdk.client import FuncXClient
 from pyhf.contrib.utils import download
 
 
-def prepare_workspace(data):
+def prepare_workspace(data, backend):
     import pyhf
 
-    pyhf.set_backend("jax")
+    pyhf.set_backend(backend)
 
     return pyhf.Workspace(data)
 
 
-def infer_hypotest(workspace, metadata, patches):
+def infer_hypotest(workspace, metadata, patches, backend):
     import time
 
     import pyhf
 
-    pyhf.set_backend("jax")
+    pyhf.set_backend(backend)
 
     tick = time.time()
     model = workspace.model(
@@ -142,6 +142,14 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="config file",
+    )
+    cli_parser.add_argument(
+        "-b",
+        "--backend",
+        dest="backend",
+        type=str,
+        default="numpy",
+        help="pyhf backend str alias",
     )
     args, unknown = cli_parser.parse_known_args()
 

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -51,6 +51,8 @@ def main(args):
         with open(args.config_file, "r") as infile:
             config = json.load(infile)
 
+    backend = args.backend
+
     pallet_path = Path(config["input_prefix"]).joinpath(config["pallet_name"])
 
     # locally get pyhf pallet for analysis
@@ -80,7 +82,7 @@ def main(args):
 
     # execute background only workspace
     prepare_task = fxc.run(
-        bkgonly_workspace, endpoint_id=pyhf_endpoint, function_id=prepare_func
+        bkgonly_workspace, backend, endpoint_id=pyhf_endpoint, function_id=prepare_func
     )
 
     # Read patchset in while background only workspace running
@@ -109,6 +111,7 @@ def main(args):
             workspace,
             patch.metadata,
             [patch.patch],
+            backend,
             endpoint_id=pyhf_endpoint,
             function_id=infer_func,
         )


### PR DESCRIPTION
```console
$ python fit_analysis.py --help
usage: fit_analysis.py [-h] [-c CONFIG_FILE] [-b BACKEND]

configuration arguments provided at run time from the CLI

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG_FILE, --config-file CONFIG_FILE
                        config file
  -b BACKEND, --backend BACKEND
                        pyhf backend str alias
```

```
* Add --backend argparse to fit_analysis.py to allow for setting the backend from the CLI
* Add use of --backend in example in README
```