### PR TITLE
feat: Add runner shell script for repeated trials

### DIFF
--- a/config/staus.json
+++ b/config/staus.json
@@ -1,6 +1,6 @@
 {
   "input_prefix": "input",
-  "pallet_name": "SUSY-2018-04-pallet",
+  "pallet_name": "staus-pallet",
   "pallet_url": "https://www.hepdata.net/record/resource/1406212?view=true",
   "analysis_dir": "Region-combined",
   "analysis_name": null

--- a/runner.sh
+++ b/runner.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+analysis_name="1Lbb"
+config_file="config/${analysis_name}.json"
+endpoint_machine="expanse"
+backend="jax"
+n_trials=10
+
+if [ ! -d "output/${analysis_name}/${endpoint_machine}" ];then
+   mkdir -p "output/${analysis_name}/${endpoint_machine}"
+fi
+
+for counter in $(seq 1 "${n_trials}");
+do
+   output_file="output/${analysis_name}/${endpoint_machine}/run_${counter}.log"
+
+   if [ -f "${output_file}" ];then
+      echo "${output_file} already exists"
+      exit 1
+   fi
+   printf "\n* Running test for %s \n\n" "${output_file}"
+   # wrap in () to captrue output of time
+   (time python fit_analysis.py --config-file "${config_file}" --backend "${backend}") > "${output_file}" 2>&1
+   tail -n 4 "${output_file}"
+   sleep 5
+done


### PR DESCRIPTION
Add a shell script that acts as a runner for repeated trials of a particular analysis to get ranges of times that can be used to calculate the variance on the mean time for a run on a particular machine/cluster.

Additionally rename the pallet for https://www.hepdata.net/record/resource/1406212?view=true

```
* Add runner shell script to run analyses repeated times on remote endpoints
   - The logged output is used for calculation of the variance on the mean run time
* Rename the config file for the ATLAS SUSY-2018-04 analysis to indicate the physics driver
```