### PR TITLE
Migrate to funcX Executor Interface

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -1,5 +1,5 @@
-funcx==0.2.2
-funcx-endpoint==0.2.2
+funcx==0.3.9
+funcx-endpoint==0.3.9
 IPython~=7.20.0
 tblib~=1.7.0
-pyhf[contrib]~=0.6.1
+pyhf[contrib]~=0.6.3

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -73,7 +73,9 @@ def main(args):
         pyhf_endpoint = str(endpoint_file.read().rstrip())
 
     # execute background only workspace
-    prepare_task_future = fx.submit(prepare_workspace, bkgonly_workspace, backend, endpoint_id=pyhf_endpoint)
+    prepare_task_future = fx.submit(
+        prepare_workspace, bkgonly_workspace, backend, endpoint_id=pyhf_endpoint
+    )
 
     # Read patchset in while background only workspace running
     with open(
@@ -92,11 +94,14 @@ def main(args):
     for patch_idx in range(n_patches):
         patch = patchset.patches[patch_idx]
         futures.append(
-            fx.submit(infer_hypotest, workspace,
-                      patch.metadata,
-                      [patch.patch],
-                      backend,
-                      endpoint_id=pyhf_endpoint)
+            fx.submit(
+                infer_hypotest,
+                workspace,
+                patch.metadata,
+                [patch.patch],
+                backend,
+                endpoint_id=pyhf_endpoint,
+            )
         )
 
     for task in as_completed(futures):


### PR DESCRIPTION
# Problem
The polling interface to funcX to find results is cumbersome and inefficient

# Approach
Upgrade to the latest version of the funcX library to use the [executor interface](https://funcx.readthedocs.io/en/latest/executor.html) to the service.

