### PR TITLE
feat: Update JAX versions to support a wider range of Pythons

### DIFF
--- a/jax-requirements.txt
+++ b/jax-requirements.txt
@@ -1,4 +1,4 @@
-jax==0.2.13
+jax==0.3.7
 # Place --find-links _before_ jaxlib to satisfy Conda
 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
 jaxlib==0.1.66+cuda110

--- a/jax-requirements.txt
+++ b/jax-requirements.txt
@@ -1,4 +1,4 @@
 jax==0.3.7
 # Place --find-links _before_ jaxlib to satisfy Conda
 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-jaxlib==0.1.66+cuda110
+jaxlib==0.3.7


### PR DESCRIPTION
Update the version of JAX used to support a larger range of CPythons. Remove the specifier on the cuda vs. nocuda jaxlib wheel as pip will be able to determine at install time what version can be installed. This also will allow for nocuda versions to be installed on macOS machines that want to replicate the environment locally.

e.g. from https://storage.googleapis.com/jax-releases/jax_releases.html for `jaxlib` `v0.3.7` there is

```
cuda11/jaxlib-0.3.7+cuda11.cudnn805-cp310-none-manylinux2014_x86_64.whl
cuda11/jaxlib-0.3.7+cuda11.cudnn805-cp37-none-manylinux2014_x86_64.whl
cuda11/jaxlib-0.3.7+cuda11.cudnn805-cp38-none-manylinux2014_x86_64.whl
cuda11/jaxlib-0.3.7+cuda11.cudnn805-cp39-none-manylinux2014_x86_64.whl
cuda11/jaxlib-0.3.7+cuda11.cudnn82-cp310-none-manylinux2014_x86_64.whl
cuda11/jaxlib-0.3.7+cuda11.cudnn82-cp37-none-manylinux2014_x86_64.whl
cuda11/jaxlib-0.3.7+cuda11.cudnn82-cp38-none-manylinux2014_x86_64.whl
cuda11/jaxlib-0.3.7+cuda11.cudnn82-cp39-none-manylinux2014_x86_64.whl
nocuda/jaxlib-0.3.7-cp310-none-manylinux2014_x86_64.whl
nocuda/jaxlib-0.3.7-cp37-none-manylinux2014_x86_64.whl
nocuda/jaxlib-0.3.7-cp38-none-manylinux2014_x86_64.whl
nocuda/jaxlib-0.3.7-cp39-none-manylinux2014_x86_64.whl
mac/jaxlib-0.3.7-cp310-none-macosx_10_9_x86_64.whl
mac/jaxlib-0.3.7-cp310-none-macosx_11_0_arm64.whl
mac/jaxlib-0.3.7-cp37-none-macosx_10_9_x86_64.whl
mac/jaxlib-0.3.7-cp38-none-macosx_10_9_x86_64.whl
mac/jaxlib-0.3.7-cp38-none-macosx_11_0_arm64.whl
mac/jaxlib-0.3.7-cp39-none-macosx_10_9_x86_64.whl
mac/jaxlib-0.3.7-cp39-none-macosx_11_0_arm64.whl
```

while for `jaxlib` `v0.1.66` there was only Linux wheels

```
cuda101/jaxlib-0.1.66+cuda101-cp36-none-manylinux2010_x86_64.whl
cuda101/jaxlib-0.1.66+cuda101-cp37-none-manylinux2010_x86_64.whl
cuda101/jaxlib-0.1.66+cuda101-cp38-none-manylinux2010_x86_64.whl
cuda101/jaxlib-0.1.66+cuda101-cp39-none-manylinux2010_x86_64.whl
cuda102/jaxlib-0.1.66+cuda102-cp36-none-manylinux2010_x86_64.whl
cuda102/jaxlib-0.1.66+cuda102-cp37-none-manylinux2010_x86_64.whl
cuda102/jaxlib-0.1.66+cuda102-cp38-none-manylinux2010_x86_64.whl
cuda102/jaxlib-0.1.66+cuda102-cp39-none-manylinux2010_x86_64.whl
cuda110/jaxlib-0.1.66+cuda110-cp36-none-manylinux2010_x86_64.whl
cuda110/jaxlib-0.1.66+cuda110-cp37-none-manylinux2010_x86_64.whl
cuda110/jaxlib-0.1.66+cuda110-cp38-none-manylinux2010_x86_64.whl
cuda110/jaxlib-0.1.66+cuda110-cp39-none-manylinux2010_x86_64.whl
cuda111/jaxlib-0.1.66+cuda111-cp36-none-manylinux2010_x86_64.whl
cuda111/jaxlib-0.1.66+cuda111-cp37-none-manylinux2010_x86_64.whl
cuda111/jaxlib-0.1.66+cuda111-cp38-none-manylinux2010_x86_64.whl
cuda111/jaxlib-0.1.66+cuda111-cp39-none-manylinux2010_x86_64.whl
nocuda/jaxlib-0.1.66-cp36-none-manylinux2010_x86_64.whl
nocuda/jaxlib-0.1.66-cp37-none-manylinux2010_x86_64.whl
nocuda/jaxlib-0.1.66-cp38-none-manylinux2010_x86_64.whl
nocuda/jaxlib-0.1.66-cp39-none-manylinux2010_x86_64.whl
```

**Squash and merge commit message**
```
* Update the version of JAX used to support a larger range of CPythons.
* Remove the specifier on the cuda vs. nocuda jaxlib wheel as pip will be able
to determine at install time what version can be installed. This also will allow for
nocuda versions to be installed on macOS machines that want to replicate the environment
locally.
```