### PR TITLE
feat: Evaluate expected CLs band and write out results

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Create a file named `endpoint_id.txt` in the top level of this repository and sa
 
 This will be read in during the run.
 
-Pass the config JSON file for the analysis you want to run to `fit_analysis.json`
+Pass the config JSON file for the analysis you want to run to `fit_analysis.py`
 
 ```
 (distributed-inference) $ python fit_analysis.py -c config/1Lbb.json -b numpy

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -84,9 +84,10 @@ def main(args):
         patchset = pyhf.PatchSet(json.load(patchset_json))
 
     workspace = prepare_task_future.result()
-    print("--------------------")
-    print("Background Workspace Constructed")
-    print("--------------------")
+    message = "# Background Workspace Constructed"
+    print("-" * len(message))
+    print(message)
+    print("-" * len(message))
 
     # execute patch fits across workers and retrieve them when done
     n_patches = len(patchset.patches)
@@ -107,7 +108,7 @@ def main(args):
     for task in as_completed(futures):
         print(task.result())
 
-    print("--------------------")
+    print("-" * len(message))
 
 
 if __name__ == "__main__":

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -125,7 +125,7 @@ def main(args):
     print("-" * len(message))
 
     with open("results.json", "w") as results_file:
-        results_file.write(json.dumps(results, indent=2))
+        results_file.write(json.dumps(results, sort_keys=True, indent=2))
 
 
 if __name__ == "__main__":

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -1,11 +1,12 @@
 import argparse
 import json
+from concurrent.futures import as_completed
 from pathlib import Path
 
 import pyhf
-from funcx import FuncXClient, FuncXExecutor
-from concurrent.futures import as_completed
 from pyhf.contrib.utils import download
+
+from funcx import FuncXClient, FuncXExecutor
 
 
 def prepare_workspace(data, backend):

--- a/fit_analysis.py
+++ b/fit_analysis.py
@@ -34,12 +34,15 @@ def infer_hypotest(workspace, metadata, patches, backend):
     )
     data = workspace.data(model)
     test_poi = 1.0
+    CLs_obs, CLs_exp_band = pyhf.infer.hypotest(
+        test_poi, data, model, return_expected_set=True, test_stat="qtilde"
+    )
+    fit_time = time.time() - tick
     return {
         "metadata": metadata,
-        "CLs_obs": float(
-            pyhf.infer.hypotest(test_poi, data, model, test_stat="qtilde")
-        ),
-        "Fit-Time": time.time() - tick,
+        "CLs_obs": float(CLs_obs),
+        "CLs_exp": [float(cls_exp) for cls_exp in CLs_exp_band],
+        "fit_time": fit_time,
     }
 
 
@@ -93,6 +96,7 @@ def main(args):
     # execute patch fits across workers and retrieve them when done
     n_patches = len(patchset.patches)
     futures = []
+    results = {}
     for patch_idx in range(n_patches):
         patch = patchset.patches[patch_idx]
         futures.append(
@@ -107,9 +111,21 @@ def main(args):
         )
 
     for task in as_completed(futures):
-        print(task.result())
+        task_result = task.result()
+        results[task_result["metadata"]["name"]] = {
+            "mass_hypotheses": task_result["metadata"]["values"],
+            "CLs_obs": task_result["CLs_obs"],
+            "CLs_exp": task_result["CLs_exp"],
+            "fit_time": task_result["fit_time"],
+        }
+        print(
+            f'{task_result["metadata"]["name"]}: {results[task_result["metadata"]["name"]]}'
+        )
 
     print("-" * len(message))
+
+    with open("results.json", "w") as results_file:
+        results_file.write(json.dumps(results, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
During the fits evaluate the expected CLs band and return it as part of the result dict. Generate a results dict as the results come in. After the run is finished write the results `dict` to disk as a JSON file. This can then be easily consumed for further analysis or visualization.

Note: This is the code that was used for the [statistical inference with pyhf and cabinetry](https://github.com/iris-hep/analysis-grand-challenge/tree/ec5184fb65bdc96a3d8ff1ac00e7fc8a8f399213/workshops/agctools2022/statistical-inference) examples at the [IRIS-HEP Analysis Grand Challenge Tools 2022 Workshop](https://indico.cern.ch/event/1126109/contributions/4780155/).

```
* During the fits evaluate the expected CLs band and return it as part of the result
dict.
* Generate a results dict as the results come in. After the run is finished write the
results dict to disk as a JSON file.
* Correct filename typo in the README.
```